### PR TITLE
Add upload component to view edits page

### DIFF
--- a/drury_mirror_portal/pages/api/getArticles.js
+++ b/drury_mirror_portal/pages/api/getArticles.js
@@ -28,12 +28,6 @@ export default async (req, res) => {
 		console.log("Article type: " + articleType);
 	}
 
-	// console.log("email", email);
-	// console.log("email.length", email.length);
-	// console.log(typeof email);
-	//console.log("session", session)
-	//const session = await getSession({req})
-
 	if (page == "draftList") {
 		isDraft = "0";
 	} else if (page == "copyEditorPortal") {

--- a/drury_mirror_portal/pages/api/saveEdits.js
+++ b/drury_mirror_portal/pages/api/saveEdits.js
@@ -13,6 +13,9 @@ export default async (req, res) => {
 		let checked = body.checked;
 		const page = body.page;
 
+		console.log("Thumbnail image", body.thumbnailImage);
+		console.log("image type", body.imageType);
+
 		// update image and image type if needed
 		if (body.thumbnailImage && body.imageType){
 			let newImageQuery = "UPDATE articles SET thumbnailImage = ?, imageType = ? where aid = ?;";

--- a/drury_mirror_portal/pages/api/saveEdits.js
+++ b/drury_mirror_portal/pages/api/saveEdits.js
@@ -13,6 +13,22 @@ export default async (req, res) => {
 		let checked = body.checked;
 		const page = body.page;
 
+		// update image and image type if needed
+		if (body.thumbnailImage && body.imageType){
+			let newImageQuery = "UPDATE articles SET thumbnailImage = ?, imageType = ? where aid = ?;";
+
+			const result = await executeQuery({
+				query: newImageQuery,
+				values: [body.thumbnailImage, body.imageType, id]
+			})
+			if (result.error) {
+				console.log("There was an error updating the article thumbnail image.");
+				return res.status(500).json({ error: result.error });
+			} else {
+				console.log(`Successfully update thumbnail image for article ${id}`)
+			}
+		}
+
 		if (page == "commentViewer" && checked) {
 			isDraft = "3";
 			let commentsQuery = "DELETE FROM comments WHERE cid = ?";

--- a/drury_mirror_portal/pages/api/saveEdits.js
+++ b/drury_mirror_portal/pages/api/saveEdits.js
@@ -17,7 +17,7 @@ export default async (req, res) => {
 		console.log("image type", body.imageType);
 
 		// update image and image type if needed
-		if (body.thumbnailImage && body.imageType){
+		if (body.thumbnailImage != undefined && body.imageType != undefined){
 			let newImageQuery = "UPDATE articles SET thumbnailImage = ?, imageType = ? where aid = ?;";
 
 			const result = await executeQuery({

--- a/drury_mirror_portal/pages/commentViewer.js
+++ b/drury_mirror_portal/pages/commentViewer.js
@@ -26,6 +26,8 @@ import {
 	Checkbox,
 } from "@mui/material";
 
+import ImageUpload from "./ImageUpload";
+
 import { withStyles } from "@mui/styles";
 
 import dynamic from "next/dynamic";
@@ -109,6 +111,9 @@ let allComments = [];
 export function CommentViewer() {
 	let [value, setValue] = useState();
 	const [getArticle, setArticle] = useState([]);
+	const [articleImage, setArticleImage] = useState(null);
+	const [getImageData, setImageData] = useState(null);
+	const [getImageType, setImageType] = useState(null);
 	const [getComments, setComments] = useState();
 	const [isError, setIsError] = useState(null);
 	const [overallComments, setOverallComments] = useState("");
@@ -156,6 +161,9 @@ export function CommentViewer() {
 						// Make sure the response was received before setting the articles
 						if (article) {
 							setArticle(article);
+						}
+						if (article.thumbnailImage) {
+							setImageData(article.thumbnailImage);
 						}
 					}
 				} else {
@@ -291,6 +299,15 @@ export function CommentViewer() {
 			}
 		}
 	}, [getComments]);
+
+	useEffect(() => {
+		setArticleImage(getImageData);
+	}, [getImageData])
+
+	const data_from_upload = (data) => {
+		setImageData(data.imageData);
+		setImageType(data.imageType);
+	}
 
 	const submit = async (event) => {
 		event.preventDefault();
@@ -470,6 +487,12 @@ export function CommentViewer() {
 						}}
 					>
 						<Grid item sx={{ width: "60%", marginLeft: 2 }}>
+							<div>
+								<ImageUpload
+									articleImage = { articleImage }
+									setter = {data_from_upload}
+								/>
+							</div>
 							<Box id="quillEditor">
 								<Box
 									sx={{

--- a/drury_mirror_portal/pages/commentViewer.js
+++ b/drury_mirror_portal/pages/commentViewer.js
@@ -320,6 +320,8 @@ export function CommentViewer() {
 			article: value,
 			id: id,
 			page: "commentViewer",
+			thumbnailImage: getImageData,
+			imageType: getImageType,
 			checked: document.getElementById("checkbox").checked,
 		};
 


### PR DESCRIPTION
# Description

This merge will add the upload image component to the comment viewer page so that when edits are submitted about the thumbnail image, the writer can change the thumbnail image. When resubmitting the article for edits, the process will detect if there has been a new image uploaded and update the article table as needed. 

## Fixes (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

